### PR TITLE
Add USAA to blacklist

### DIFF
--- a/extension/js/blacklist2.js
+++ b/extension/js/blacklist2.js
@@ -14445,6 +14445,7 @@ DEFAULT_BLACKLIST=[
 "umoo.com",
 "unionsecuritiescommodityfutures.com",
 "usa-stocks.de",
+"usaa.com",
 "utradeph.com",
 "vanguard.com",
 "virtualstockexchange.com",


### PR DESCRIPTION
Added `usaa.com`. Should `www.usaa.com` be added also?